### PR TITLE
Use JOGL2 to make PrismaTD compile on Debian.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <project name="PrismaTD" basedir="." default="main">
-	<property name="src.dir" value="src"/>
+	<property name="src.dir" value="towerdefence"/>
 	<property name="build.dir" value="build"/>
 	<property name="classes.dir" value="${build.dir}/classes"/>
 	<property name="jar.dir" value="${build.dir}/jar"/>
@@ -7,8 +7,8 @@
 	<property name="main-class" value="com.avona.games.towerdefence.awt.MainLoop"/>
 
 	<path id="classpath">
-		<path location="/usr/share/java/jogl.jar"/>
-		<path location="/usr/share/java/gluegen-rt.jar"/>
+		<path location="/usr/share/java/jogl2.jar"/>
+		<path location="/usr/share/java/gluegen2-rt.jar"/>
 		<path location="/usr/share/java/junit4.jar"/>
 		<fileset dir="${lib.dir}" includes="**/*.jar" erroronmissingdir="false"/>
 	</path>

--- a/prismatd-build.ubuntu.sh
+++ b/prismatd-build.ubuntu.sh
@@ -3,7 +3,7 @@
 ANTTASK="clean-build"
 
 JDK="default-jdk"
-JOGL="libjogl-java"
+JOGL="libjogl2-java"
 ANT="ant"
 JUNIT="junit4"
 

--- a/prismatd.ubuntu.sh
+++ b/prismatd.ubuntu.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 PRISMATD="build/jar/PrismaTD.jar"
-JOGL="/usr/share/java/jogl.jar"
-GLUEGEN="/usr/share/java/gluegen-rt.jar"
+JOGL="/usr/share/java/jogl2.jar"
+GLUEGEN="/usr/share/java/gluegen2-rt.jar"
 
 LIBRARY="/usr/lib/jni/"
 


### PR DESCRIPTION
Debian testing and up only ships JOGL2, not JOGL1, which means that PrismaTD does not compile anymore. We can either roll forward or somehow make the build conditional. I chose the former for simplicity.